### PR TITLE
feat: add TLS support for nginx and apache (tier 2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,18 @@ These variables apply to all variants (nginx, Apache, Caddy). Not every setting 
 | `LOGLEVEL` | `warn` | Server error log level | ✅ | ✅ | ✅ |
 | `ACCESSLOG` | `/dev/stdout` | Access log destination | ✅ | ✅ | ✅ |
 | `ERRORLOG` | `/dev/stderr` | Error log destination | ✅ | ✅ | — |
+| `SSL_PORT` | `8443` | HTTPS listen port | ✅ | ✅ | — |
+| `SSL_CERT_FILE` | (auto-generated) | TLS certificate path | ✅ | ✅ | — |
+| `SSL_CERT_KEY_FILE` | (auto-generated) | TLS private key path | ✅ | ✅ | — |
+| `SSL_PROTOCOLS` | `TLSv1.2 TLSv1.3` | Allowed TLS protocols | ✅ | ✅ | — |
+| `SSL_CIPHERS` | Mozilla modern | TLS cipher suites | ✅ | ✅ | — |
+| `SSL_PREFER_CIPHERS` | `off` | Prefer server ciphers | ✅ | — | — |
+| `SSL_DH_BITS` | `2048` | DH parameter size (2048/4096) | ✅ | — | — |
+| `SSL_OCSP_STAPLING` | `off` | OCSP stapling | ✅ | — | — |
+| `SSL_VERIFY` | `off` | Client certificate verification | ✅ | — | — |
+| `SSL_VERIFY_DEPTH` | `1` | Client cert chain depth | ✅ | — | — |
+
+A self-signed certificate is generated automatically at startup if no certificate is mounted. To use your own certificate, mount it at the `SSL_CERT_FILE` and `SSL_CERT_KEY_FILE` paths. Caddy handles TLS automatically via its built-in ACME support.
 
 #### Caddy-only
 

--- a/README.md
+++ b/README.md
@@ -153,8 +153,8 @@ These variables apply to all variants (nginx, Apache, Caddy). Not every setting 
 | `SSL_PORT` | `8443` | HTTPS listen port | ✅ | ✅ | — |
 | `SSL_CERT_FILE` | (auto-generated) | TLS certificate path | ✅ | ✅ | — |
 | `SSL_CERT_KEY_FILE` | (auto-generated) | TLS private key path | ✅ | ✅ | — |
-| `SSL_PROTOCOLS` | `TLSv1.2 TLSv1.3` | Allowed TLS protocols | ✅ | ✅ | — |
-| `SSL_CIPHERS` | Mozilla modern | TLS cipher suites | ✅ | ✅ | — |
+| `SSL_PROTOCOLS` | nginx: `TLSv1.2 TLSv1.3`, apache: `all -SSLv3 -TLSv1 -TLSv1.1` | Allowed TLS protocols (syntax differs per server) | ✅ | ✅ | — |
+| `SSL_CIPHERS` | [Mozilla intermediate](https://ssl-config.mozilla.org/) | TLS cipher suites | ✅ | ✅ | — |
 | `SSL_PREFER_CIPHERS` | `off` | Prefer server ciphers | ✅ | — | — |
 | `SSL_DH_BITS` | `2048` | DH parameter size (2048/4096) | ✅ | — | — |
 | `SSL_OCSP_STAPLING` | `off` | OCSP stapling | ✅ | — | — |

--- a/apache/Dockerfile
+++ b/apache/Dockerfile
@@ -97,14 +97,16 @@ COPY --from=crs-release /opt/coraza /opt/coraza
 
 RUN set -eux; \
     apt-get update -qq; \
-    apt-get install -qq --no-install-recommends gettext-base; \
+    apt-get install -qq --no-install-recommends gettext-base openssl; \
     rm -rf /var/lib/apt/lists/*; \
     ldconfig; \
-    # Enable required modules and make listen port configurable
+    # Enable required modules and make ports configurable
     sed -i \
       -e 's/^#LoadModule proxy_module/LoadModule proxy_module/' \
       -e 's/^#LoadModule proxy_http_module/LoadModule proxy_http_module/' \
-      -e 's|Listen 80|Listen ${PORT}|' \
+      -e 's/^#LoadModule ssl_module/LoadModule ssl_module/' \
+      -e 's/^#LoadModule socache_shmcb_module/LoadModule socache_shmcb_module/' \
+      -e 's|Listen 80|Listen ${PORT}\nListen ${SSL_PORT}|' \
       /usr/local/apache2/conf/httpd.conf; \
     # Make worker limits configurable via env var
     sed -i -E 's|(MaxRequestWorkers[ ]+)[0-9]+|\1${WORKER_CONNECTIONS}|' \
@@ -172,6 +174,11 @@ ENV \
     PROXY_TIMEOUT=60 \
     SERVER_NAME=localhost \
     SERVER_TOKENS=Prod \
+    SSL_CERT_FILE=/usr/local/apache2/conf/server.crt \
+    SSL_CERT_KEY_FILE=/usr/local/apache2/conf/server.key \
+    SSL_CIPHERS="ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384" \
+    SSL_PORT=8443 \
+    SSL_PROTOCOLS="all -SSLv3 -TLSv1 -TLSv1.1" \
     WORKER_CONNECTIONS=1024 \
     PARANOIA=1 \
     ANOMALY_INBOUND=5 \

--- a/apache/Dockerfile
+++ b/apache/Dockerfile
@@ -106,6 +106,7 @@ RUN set -eux; \
       -e 's/^#LoadModule proxy_http_module/LoadModule proxy_http_module/' \
       -e 's/^#LoadModule ssl_module/LoadModule ssl_module/' \
       -e 's/^#LoadModule socache_shmcb_module/LoadModule socache_shmcb_module/' \
+      -e 's/^#LoadModule headers_module/LoadModule headers_module/' \
       -e 's|Listen 80|Listen ${PORT}\nListen ${SSL_PORT}|' \
       /usr/local/apache2/conf/httpd.conf; \
     # Make worker limits configurable via env var

--- a/apache/entrypoint.sh
+++ b/apache/entrypoint.sh
@@ -10,14 +10,14 @@ chown -R www-data:www-data "${CORAZA_TMP_DIR:-/tmp/coraza}" \
                            "${CORAZA_AUDIT_STORAGE_DIR:-/var/log/coraza/audit}"
 
 # Generate self-signed certificate if none provided
-if [ ! -f "${SSL_CERT_FILE}" ]; then
+if [ ! -f "${SSL_CERT_FILE}" ] || [ ! -f "${SSL_CERT_KEY_FILE}" ]; then
     echo "Generating self-signed TLS certificate..."
-    cert_dir=$(dirname "${SSL_CERT_FILE}")
-    mkdir -p "${cert_dir}"
+    mkdir -p "$(dirname "${SSL_CERT_FILE}")" "$(dirname "${SSL_CERT_KEY_FILE}")"
     openssl req -x509 -newkey rsa:2048 -nodes \
         -keyout "${SSL_CERT_KEY_FILE}" \
         -out "${SSL_CERT_FILE}" \
-        -days 365 -subj "/CN=${SERVER_NAME:-localhost}" 2>/dev/null
+        -days 365 -subj "/CN=${SERVER_NAME:-localhost}" \
+        -addext "subjectAltName=DNS:${SERVER_NAME:-localhost}"
 fi
 
 echo "Generating configuration files..."

--- a/apache/entrypoint.sh
+++ b/apache/entrypoint.sh
@@ -9,6 +9,17 @@ mkdir -p "${CORAZA_TMP_DIR:-/tmp/coraza}" \
 chown -R www-data:www-data "${CORAZA_TMP_DIR:-/tmp/coraza}" \
                            "${CORAZA_AUDIT_STORAGE_DIR:-/var/log/coraza/audit}"
 
+# Generate self-signed certificate if none provided
+if [ ! -f "${SSL_CERT_FILE}" ]; then
+    echo "Generating self-signed TLS certificate..."
+    cert_dir=$(dirname "${SSL_CERT_FILE}")
+    mkdir -p "${cert_dir}"
+    openssl req -x509 -newkey rsa:2048 -nodes \
+        -keyout "${SSL_CERT_KEY_FILE}" \
+        -out "${SSL_CERT_FILE}" \
+        -days 365 -subj "/CN=${SERVER_NAME:-localhost}" 2>/dev/null
+fi
+
 echo "Generating configuration files..."
 
 defined_envs=$(printf '${%s} ' $(awk "END { for (name in ENVIRON) { print ( name ~ /${filter}/ ) ? name : \"\" } }" < /dev/null ))

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -64,6 +64,7 @@ services:
       - waf
     ports:
       - "8081:8080"
+      - "8444:8443"
     environment:
       - BACKEND=whoami:80
       - CORAZA_RULE_ENGINE=On
@@ -91,6 +92,7 @@ services:
       - waf
     ports:
       - "8082:8080"
+      - "8445:8443"
     environment:
       - BACKEND=whoami:80
       - CORAZA_RULE_ENGINE=On

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -93,7 +93,11 @@ RUN set -eux; \
       /opt/coraza/owasp-crs; \
     cp -r /var/tmp/owasp-crs/rules /opt/coraza/owasp-crs; \
     cp -r /var/tmp/owasp-crs/plugins /opt/coraza/owasp-crs; \
-    cp /var/tmp/owasp-crs/crs-setup.conf.example /opt/coraza/config/crs-setup.conf
+    cp /var/tmp/owasp-crs/crs-setup.conf.example /opt/coraza/config/crs-setup.conf; \
+    # Download DH params for TLS
+    mkdir -p /usr/share/TLS; \
+    curl -sSL https://ssl-config.mozilla.org/ffdhe2048.txt -o /usr/share/TLS/dhparam-2048.pem; \
+    curl -sSL https://ssl-config.mozilla.org/ffdhe4096.txt -o /usr/share/TLS/dhparam-4096.pem
 
 ## Stage 4: Runtime (unprivileged image)
 FROM nginxinc/nginx-unprivileged:${NGINX_VERSION}
@@ -103,10 +107,11 @@ USER root
 COPY --from=go-builder /usr/local/lib/libcoraza.so /usr/local/lib/
 COPY --from=nginx-builder /usr/lib/nginx/modules/ngx_http_coraza_module.so /usr/lib/nginx/modules/
 COPY --from=crs-release /opt/coraza /opt/coraza
+COPY --from=crs-release /usr/share/TLS/dhparam-* /etc/ssl/certs/
 
 RUN set -eux; \
     apt-get update -qq; \
-    apt-get install -qq --no-install-recommends gettext-base; \
+    apt-get install -qq --no-install-recommends gettext-base openssl; \
     rm -rf /var/lib/apt/lists/*; \
     ldconfig
 
@@ -171,6 +176,16 @@ ENV \
     PROXY_TIMEOUT=60s \
     SERVER_NAME=localhost \
     SERVER_TOKENS=off \
+    SSL_CERT_FILE=/etc/nginx/conf/server.crt \
+    SSL_CERT_KEY_FILE=/etc/nginx/conf/server.key \
+    SSL_CIPHERS="ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384" \
+    SSL_DH_BITS=2048 \
+    SSL_OCSP_STAPLING=off \
+    SSL_PORT=8443 \
+    SSL_PREFER_CIPHERS=off \
+    SSL_PROTOCOLS="TLSv1.2 TLSv1.3" \
+    SSL_VERIFY=off \
+    SSL_VERIFY_DEPTH=1 \
     WORKER_CONNECTIONS=1024 \
     PARANOIA=1 \
     ANOMALY_INBOUND=5 \
@@ -178,6 +193,7 @@ ENV \
     BLOCKING_PARANOIA=1
 
 EXPOSE ${PORT}
+EXPOSE ${SSL_PORT}
 
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["nginx", "-g", "daemon off;"]

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -96,8 +96,8 @@ RUN set -eux; \
     cp /var/tmp/owasp-crs/crs-setup.conf.example /opt/coraza/config/crs-setup.conf; \
     # Download DH params for TLS
     mkdir -p /usr/share/TLS; \
-    curl -sSL https://ssl-config.mozilla.org/ffdhe2048.txt -o /usr/share/TLS/dhparam-2048.pem; \
-    curl -sSL https://ssl-config.mozilla.org/ffdhe4096.txt -o /usr/share/TLS/dhparam-4096.pem
+    curl -fsSL https://ssl-config.mozilla.org/ffdhe2048.txt -o /usr/share/TLS/dhparam-2048.pem; \
+    curl -fsSL https://ssl-config.mozilla.org/ffdhe4096.txt -o /usr/share/TLS/dhparam-4096.pem
 
 ## Stage 4: Runtime (unprivileged image)
 FROM nginxinc/nginx-unprivileged:${NGINX_VERSION}

--- a/nginx/entrypoint.sh
+++ b/nginx/entrypoint.sh
@@ -7,6 +7,17 @@ mkdir -p "${CORAZA_TMP_DIR:-/tmp/coraza}" \
          "${CORAZA_UPLOAD_DIR:-/tmp/coraza/upload}" \
          "${CORAZA_AUDIT_STORAGE_DIR:-/var/log/coraza/audit}"
 
+# Generate self-signed certificate if none provided
+if [ ! -f "${SSL_CERT_FILE}" ]; then
+    echo "Generating self-signed TLS certificate..."
+    cert_dir=$(dirname "${SSL_CERT_FILE}")
+    mkdir -p "${cert_dir}"
+    openssl req -x509 -newkey rsa:2048 -nodes \
+        -keyout "${SSL_CERT_KEY_FILE}" \
+        -out "${SSL_CERT_FILE}" \
+        -days 365 -subj "/CN=${SERVER_NAME:-localhost}" 2>/dev/null
+fi
+
 echo "Generating configuration files..."
 
 defined_envs=$(printf '${%s} ' $(awk "END { for (name in ENVIRON) { print ( name ~ /${filter}/ ) ? name : \"\" } }" < /dev/null ))

--- a/nginx/entrypoint.sh
+++ b/nginx/entrypoint.sh
@@ -8,14 +8,14 @@ mkdir -p "${CORAZA_TMP_DIR:-/tmp/coraza}" \
          "${CORAZA_AUDIT_STORAGE_DIR:-/var/log/coraza/audit}"
 
 # Generate self-signed certificate if none provided
-if [ ! -f "${SSL_CERT_FILE}" ]; then
+if [ ! -f "${SSL_CERT_FILE}" ] || [ ! -f "${SSL_CERT_KEY_FILE}" ]; then
     echo "Generating self-signed TLS certificate..."
-    cert_dir=$(dirname "${SSL_CERT_FILE}")
-    mkdir -p "${cert_dir}"
+    mkdir -p "$(dirname "${SSL_CERT_FILE}")" "$(dirname "${SSL_CERT_KEY_FILE}")"
     openssl req -x509 -newkey rsa:2048 -nodes \
         -keyout "${SSL_CERT_KEY_FILE}" \
         -out "${SSL_CERT_FILE}" \
-        -days 365 -subj "/CN=${SERVER_NAME:-localhost}" 2>/dev/null
+        -days 365 -subj "/CN=${SERVER_NAME:-localhost}" \
+        -addext "subjectAltName=DNS:${SERVER_NAME:-localhost}"
 fi
 
 echo "Generating configuration files..."

--- a/src/templates/apache-vhost.conf
+++ b/src/templates/apache-vhost.conf
@@ -26,6 +26,8 @@ LogLevel ${LOGLEVEL}
     SSLProtocol ${SSL_PROTOCOLS}
     SSLCipherSuite ${SSL_CIPHERS}
 
+    RequestHeader set X-Forwarded-Proto "https"
+
     # Reverse proxy to backend
     ProxyPreserveHost On
     ProxyPass / http://${BACKEND}/

--- a/src/templates/apache-vhost.conf
+++ b/src/templates/apache-vhost.conf
@@ -18,3 +18,16 @@ LogLevel ${LOGLEVEL}
     ProxyPass / http://${BACKEND}/
     ProxyPassReverse / http://${BACKEND}/
 </VirtualHost>
+
+<VirtualHost *:${SSL_PORT}>
+    SSLEngine on
+    SSLCertificateFile ${SSL_CERT_FILE}
+    SSLCertificateKeyFile ${SSL_CERT_KEY_FILE}
+    SSLProtocol ${SSL_PROTOCOLS}
+    SSLCipherSuite ${SSL_CIPHERS}
+
+    # Reverse proxy to backend
+    ProxyPreserveHost On
+    ProxyPass / http://${BACKEND}/
+    ProxyPassReverse / http://${BACKEND}/
+</VirtualHost>

--- a/src/templates/nginx.conf
+++ b/src/templates/nginx.conf
@@ -37,4 +37,34 @@ http {
             proxy_read_timeout ${PROXY_TIMEOUT};
         }
     }
+
+    server {
+        listen ${SSL_PORT} ssl;
+        server_name ${SERVER_NAME};
+
+        ssl_certificate ${SSL_CERT_FILE};
+        ssl_certificate_key ${SSL_CERT_KEY_FILE};
+        ssl_protocols ${SSL_PROTOCOLS};
+        ssl_ciphers ${SSL_CIPHERS};
+        ssl_prefer_server_ciphers ${SSL_PREFER_CIPHERS};
+        ssl_session_timeout 1d;
+        ssl_session_cache shared:MozSSL:10m;
+        ssl_session_tickets off;
+        ssl_dhparam /etc/ssl/certs/dhparam-${SSL_DH_BITS}.pem;
+        ssl_stapling ${SSL_OCSP_STAPLING};
+
+        ssl_verify_client ${SSL_VERIFY};
+        ssl_verify_depth ${SSL_VERIFY_DEPTH};
+
+        location / {
+            proxy_pass http://backend;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_connect_timeout ${PROXY_TIMEOUT};
+            proxy_send_timeout ${PROXY_TIMEOUT};
+            proxy_read_timeout ${PROXY_TIMEOUT};
+        }
+    }
 }


### PR DESCRIPTION
Second pass on #49 — adds HTTPS support.

nginx and apache now listen on both HTTP (`PORT`, default 8080) and HTTPS (`SSL_PORT`, default 8443). A self-signed certificate is generated at startup if none is mounted.

New env vars for nginx and apache:
- `SSL_PORT`, `SSL_CERT_FILE`, `SSL_CERT_KEY_FILE`, `SSL_PROTOCOLS`, `SSL_CIPHERS`
- nginx also gets: `SSL_PREFER_CIPHERS`, `SSL_DH_BITS`, `SSL_OCSP_STAPLING`, `SSL_VERIFY`, `SSL_VERIFY_DEPTH`

DH params from Mozilla (RFC 7919 ffdhe2048/ffdhe4096), same approach as modsecurity-crs-docker.

Caddy already handles TLS automatically via ACME — no changes needed.

Tested: HTTP and HTTPS on both nginx and apache, normal requests 200, SQLi blocked 403.

cc @fzipi