### PR TITLE
fix: remove invalid quoting from FROM lines in caddy/Dockerfile

### DIFF
--- a/caddy/Dockerfile
+++ b/caddy/Dockerfile
@@ -2,14 +2,14 @@
 ARG CADDY_VERSION="n/a"
 
 # Use official Caddy builder image
-FROM caddy:"${CADDY_VERSION}-builder" AS builder-caddy
+FROM caddy:${CADDY_VERSION}-builder AS builder-caddy
 
 # Build Caddy with Coraza
 RUN --mount=type=cache,target=/go,id=caddy \
   xcaddy build --with github.com/corazawaf/coraza-caddy
 
 # Use official caddy builder image to get Core Rule Set
-FROM caddy:"${CADDY_VERSION}-builder" AS builder-crs
+FROM caddy:${CADDY_VERSION}-builder AS builder-crs
 
 # Set OWASP ModSecurity core rule set release tag to check out
 # Available tags are on the GitHub releases page here: https://github.com/coreruleset/coreruleset/tags
@@ -57,7 +57,7 @@ RUN set -eux; \
   cp /var/tmp/owasp-crs/crs-setup.conf.example /opt/coraza/config/crs-setup.conf
 
 # Switch to official Caddy container
-FROM caddy:"$CADDY_VERSION"
+FROM caddy:${CADDY_VERSION}
 
 # Add libcap to allow Caddy to bind to port 80/443 with a low privledged account
 # If this is not required it may be disabled (eg. if Caddy is listening on a high port)


### PR DESCRIPTION
## Summary
- caddy/Dockerfile quoted the image reference in its three `FROM` lines (`FROM caddy:"${CADDY_VERSION}-builder"`), unlike `nginx/Dockerfile` and `apache/Dockerfile` which use the unquoted `FROM nginx:${NGINX_VERSION}` style
- Renovate's Dockerfile parser takes the quotes literally, producing a malformed dependency name (`caddy:"n/a-builder"`) that breaks its registry lookup with `Request Error: cannot parse url`, causing the Renovate run to exit non-zero
- Docker's buildkit tolerates the quotes at actual build time, so the image build itself was unaffected — this only broke Renovate's dependency extraction

## Test plan
- [x] Built `caddy/Dockerfile` locally with the real build args from `docker-bake.hcl` (`CADDY_VERSION`, `CRS_VERSION`, `CORAZA_VERSION`) — image builds successfully, unchanged from before

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container image version references to improve build configuration consistency.
  * No user-facing functionality or runtime behavior changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->