### PR TITLE
fix: use a real default for CADDY_VERSION in caddy/Dockerfile

### DIFF
--- a/caddy/Dockerfile
+++ b/caddy/Dockerfile
@@ -1,5 +1,5 @@
 # Set Caddy release tag
-ARG CADDY_VERSION="n/a"
+ARG CADDY_VERSION="2.11.2"
 
 # Use official Caddy builder image
 FROM caddy:${CADDY_VERSION}-builder AS builder-caddy


### PR DESCRIPTION
## Summary
- Follow-up to #69, which removed the invalid quoting from caddy/Dockerfile's `FROM` lines but left the underlying `ARG CADDY_VERSION="n/a"` placeholder in place
- Renovate still failed: since `"n/a"` contains a `/`, substituting it into `FROM caddy:${CADDY_VERSION}-builder` produces `caddy:n/a-builder`, which Renovate's docker datasource misparses as registry-host `caddy:n` (an invalid port) plus repository `a-builder`, causing `Request Error: cannot parse url` and a non-zero exit
- `nginx/Dockerfile` and `apache/Dockerfile` avoid this because their top-level version ARGs (`NGINX_VERSION`, `HTTPD_VERSION`) already default to real version strings instead of `"n/a"`
- Changed `ARG CADDY_VERSION="n/a"` to `ARG CADDY_VERSION="2.11.2"`, matching the current `caddy-version` default in `docker-bake.hcl`

## Test plan
- [x] Rebuilt `caddy/Dockerfile` locally with the real build args from `docker-bake.hcl` — image builds successfully, unchanged from before

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the bundled web server to Caddy 2.11.2 for more consistent builds and runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->