### PR TITLE
chore: pin nginx to stable branch, fix coraza-nginx version drift

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,10 +206,10 @@ The following configuration paths are shared across all variants:
 | -------- | ------- | ----------- |
 | `CRS_VERSION` | `4.25.0` | OWASP CRS release version (LTS) |
 | `CADDY_VERSION` | `2.11.2` | Caddy Docker tag (caddy variant) |
-| `NGINX_VERSION` | `1.28.2` | nginx image version (nginx variant) |
+| `NGINX_VERSION` | `1.30.4` | nginx image version (nginx variant) |
 | `HTTPD_VERSION` | `2.4` | httpd image version (apache variant) |
 | `LIBCORAZA_VERSION` | `v1.2.0` | libcoraza release (nginx/apache variants) |
-| `CORAZA_NGINX_VERSION` | `0.10.1` | coraza-nginx release (nginx variant) |
+| `CORAZA_NGINX_VERSION` | `0.11.4` | coraza-nginx release (nginx variant) |
 | `CORAZA_APACHE_VERSION` | `0.0.1` | coraza-apache release (apache variant) |
 
 ## Building

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -47,7 +47,7 @@ variable "coraza-apache-version" {
 
 variable "nginx-version" {
     # renovate: depName=nginxinc/nginx-unprivileged datasource=docker
-    default = "1.31.1"
+    default = "1.30.4"
 }
 
 variable "httpd-version" {

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -55,9 +55,9 @@ services:
         # renovate: depName=corazawaf/libcoraza datasource=github-releases
         LIBCORAZA_VERSION: "v1.2.0"
         # renovate: depName=corazawaf/coraza-nginx datasource=github-releases
-        CORAZA_NGINX_VERSION: "0.10.1"
+        CORAZA_NGINX_VERSION: "0.11.4"
         # renovate: depName=nginxinc/nginx-unprivileged datasource=docker
-        NGINX_VERSION: "1.28.2"
+        NGINX_VERSION: "1.30.4"
     depends_on:
       - whoami
     networks:

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-ARG NGINX_VERSION="1.28.2"
+ARG NGINX_VERSION="1.30.4"
 ARG GOLANG_VERSION="1.25"
 
 ## Stage 1: Build libcoraza from source

--- a/renovate.json
+++ b/renovate.json
@@ -38,5 +38,13 @@
       "depNameTemplate": "coreruleset/coreruleset",
       "datasourceTemplate": "github-releases"
     }
+  ],
+  "packageRules": [
+    {
+      "description": "nginx uses odd minors for mainline and even minors for stable; only track stable",
+      "matchDatasources": ["docker"],
+      "matchPackageNames": ["nginx", "nginxinc/nginx-unprivileged"],
+      "allowedVersions": "/^\\d+\\.\\d*[02468]\\.\\d+$/"
+    }
   ]
 }


### PR DESCRIPTION
## Summary
- Pin nginx to the stable release (`1.30.4`) across `nginx/Dockerfile`, `docker-bake.hcl`, `docker-compose.yaml`, and `README.md`. nginx uses odd minors for mainline and even minors for stable; `docker-bake.hcl` had drifted to `1.31.1` (mainline).
- Add a `renovate.json` packageRule restricting `nginx` / `nginxinc/nginx-unprivileged` (docker datasource) to even-minor versions, so renovate only proposes stable releases going forward.
- Align `CORAZA_NGINX_VERSION` across `docker-compose.yaml` and `README.md` to `0.11.4` (latest release), matching what `docker-bake.hcl` already had.

## Test plan
- [ ] `docker compose --profile nginx build` succeeds with the new versions
- [ ] Renovate run picks up the new `allowedVersions` constraint and stops proposing mainline nginx bumps

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated the bundled NGINX version to 1.30.4.
  * Updated the Coraza NGINX version to 0.11.4 across supported build and deployment configurations.
  * Aligned documented version information with the current release configuration.

* **Maintenance**
  * Added safeguards to keep automatic NGINX updates aligned with stable even-numbered minor releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->