### PR TITLE
fix(ci): skip buildx warnings when parsing bake metadata

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -82,10 +82,10 @@ jobs:
         env:
           METADATA: ${{ steps.build-and-push.outputs.metadata }}
         run: |
-          DIGEST=$(echo ${METADATA} | jq -r '.[] | ."containerimage.digest"')
-          TAGS=$(echo ${METADATA} | jq -r '.[] | ."image.name" | tostring' | tr ',' '\n')
-          images=""
+          DIGEST=$(jq -r '.[] | objects | ."containerimage.digest"' <<<"${METADATA}")
+          TAGS=$(jq -r '.[] | objects | ."image.name"' <<<"${METADATA}" | tr ',' '\n')
+          images=()
           for tag in ${TAGS}; do
-            images+="${tag}@${DIGEST} "
+            images+=("${tag}@${DIGEST}")
           done
-          cosign sign --yes ${images}
+          cosign sign --yes "${images[@]}"


### PR DESCRIPTION
The signing step in `publish.yml` read the bake metadata with `jq '.[] | ."containerimage.digest"'`, which iterates every top-level value. When a build emits warnings, the metadata gains a `buildx.build.warnings` key holding an array, and jq fails with `Cannot index array with string "containerimage.digest"` — the step exits 5.

This is what broke [the caddy jobs in run 32991471858](https://github.com/coreruleset/coraza-crs-docker/actions/runs/32991471858/job/98249942375): `caddy/Dockerfile` triggers `InvalidDefaultArgInFrom` (Renovate pinned `CADDY_VERSION` to `2.11.3@sha256:…`, so the default expands to `caddy:2.11.3@sha256:…-builder`), so its metadata carries warnings while nginx/apache's does not. The images were built and pushed; only signing failed.

`| objects` skips the non-target entries. The images are also collected in an array so the `cosign sign` call no longer depends on word splitting, which clears the SC2086 actionlint warning on this step.

Verified with `bash` against the real metadata from the failing run and against warning-free metadata.

The caddy images from that release are pushed but unsigned and will need a one-off `cosign sign`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved image-signing reliability by correctly handling build metadata and image references.
  * Ensured multiple image references are passed separately during signing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->