### PR TITLE
fix: use compatible libcoraza version with Nginx

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ The following configuration paths are shared across all variants:
 | `CADDY_VERSION` | `2.11.2` | Caddy Docker tag (caddy variant) |
 | `NGINX_VERSION` | `1.30.4` | nginx image version (nginx variant) |
 | `HTTPD_VERSION` | `2.4` | httpd image version (apache variant) |
-| `LIBCORAZA_VERSION` | `v1.2.0` | libcoraza release (nginx/apache variants) |
+| `LIBCORAZA_VERSION` | `v1.6.0` | libcoraza release (nginx/apache variants) |
 | `CORAZA_NGINX_VERSION` | `0.11.4` | coraza-nginx release (nginx variant) |
 | `CORAZA_APACHE_VERSION` | `0.0.1` | coraza-apache release (apache variant) |
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -53,7 +53,7 @@ services:
         # renovate: depName=golang datasource=docker
         GOLANG_VERSION: "1.25"
         # renovate: depName=corazawaf/libcoraza datasource=github-releases
-        LIBCORAZA_VERSION: "v1.2.0"
+        LIBCORAZA_VERSION: "v1.6.0"
         # renovate: depName=corazawaf/coraza-nginx datasource=github-releases
         CORAZA_NGINX_VERSION: "0.11.4"
         # renovate: depName=nginxinc/nginx-unprivileged datasource=docker
@@ -81,7 +81,7 @@ services:
         # renovate: depName=golang datasource=docker
         GOLANG_VERSION: "1.25"
         # renovate: depName=corazawaf/libcoraza datasource=github-releases
-        LIBCORAZA_VERSION: "v1.2.0"
+        LIBCORAZA_VERSION: "v1.6.0"
         # renovate: depName=corazawaf/coraza-apache datasource=github-releases
         CORAZA_APACHE_VERSION: "0.0.1"
         # renovate: depName=httpd datasource=docker


### PR DESCRIPTION
Update same version also to Apache

Fixes #80 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the documented LibCoraza version from v1.2.0 to v1.6.0.

* **Maintenance**
  * Updated the NGINX and Apache container configurations to use LibCoraza v1.6.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->