### PR TITLE
fix(caddy): bump coraza-caddy to v2.6.0, v2.5.0 breaks WebSocket upgrades

### DIFF
--- a/caddy/Dockerfile
+++ b/caddy/Dockerfile
@@ -1,5 +1,5 @@
 # Set Caddy release tag
-ARG CADDY_VERSION="2.11.3@sha256:ec18ee54aab3315c22e25f3b2babda73ff8007d39b13b3bd1bfffa2f0444c7d9"
+ARG CADDY_VERSION="2.11.4@sha256:df7f1c2fb114453b951de51a98efc010db1655a92c2e86be6706714e2417a78d"
 
 # Use official Caddy builder image
 FROM caddy:${CADDY_VERSION}-builder AS builder-caddy

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -17,12 +17,12 @@ variable "crs-versions" {
 
 variable "caddy-version" {
     # renovate: depName=caddy datasource=docker
-    default = "2.11.3"
+    default = "2.11.4"
 }
 
 variable "coraza-version" {
     # renovate: depName=corazawaf/coraza-caddy datasource=github-releases
-    default = "v2.5.0"
+    default = "v2.6.0"
 }
 
 variable "golang-version" {

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -28,9 +28,9 @@ services:
         # renovate: depName=coreruleset/coreruleset datasource=github-releases
         CRS_VERSION: "4.25.0"
         # renovate: depName=caddy datasource=docker
-        CADDY_VERSION: "2.11.2"
+        CADDY_VERSION: "2.11.4"
         # renovate: depName=corazawaf/coraza-caddy datasource=github-releases
-        CORAZA_VERSION: "v2.5.0"
+        CORAZA_VERSION: "v2.6.0"
     depends_on:
       - whoami
     networks:


### PR DESCRIPTION
## Problem

Since #78, `CORAZA_VERSION` is actually consumed, so the pinned `v2.5.0` is what the
published caddy images now ship. That version **breaks every WebSocket upgrade behind the
WAF**, in `SecRuleEngine On` and `DetectionOnly` alike.

Against the image published right after #78 merged, with a WebSocket-capable backend
(`jmalloc/echo-server`, since `traefik/whoami` does not upgrade):

```console
$ curl -sSi --http1.1 -m 5 -H 'Host: localhost' -A 'Mozilla/5.0' -H 'Accept: */*' \
    -H 'Connection: Upgrade' -H 'Upgrade: websocket' \
    -H 'Sec-WebSocket-Version: 13' -H 'Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==' \
    http://127.0.0.1:18091/ws
curl: (1) Received HTTP/0.9 when not allowed
```

No status line is ever sent — the frames arrive with no HTTP response in front of them,
which is what curl reports as HTTP/0.9. Real clients just hang until they give up. Plain
HTTP through the same container is unaffected (`200`), and the CRS still blocks attacks.

## Cause

`rwInterceptor.WriteHeader()` only *records* the status code; it is written downstream on
the first `Write()`, so that a phase 4 rule can still replace it. On a `101` the caller
hijacks the connection immediately after `WriteHeader()` and no `Write()` ever follows:
the status line dies in the interceptor, and `processResponse` then writes to the hijacked
connection (`response.WriteHeader on hijacked connection`).

corazawaf/coraza-caddy#262 fixes exactly this — a `hijackerTracker` marks the connection
and the 101 is flushed immediately. It shipped in **v2.6.0 on 2026-08-24**, two days before
#78 merged, so the pin never caught up.

## Why `caddy-version` moves in the same commit

coraza-caddy v2.6.0 requires caddy v2.11.4, and xcaddy refuses to build against an older
one:

```
go: github.com/corazawaf/coraza-caddy/v2@v2.6.0 requires
    github.com/caddyserver/caddy/v2@v2.11.4, not github.com/caddyserver/caddy/v2@v2.11.3
2026/08/27 08:42:17 [FATAL] exit status 1
```

So a lone renovate bump of either variable fails CI; the two have to land together. Happy
to split them if you would rather have caddy bumped by renovate first and rebase this on
top.

`docker-compose.yaml` is realigned on `docker-bake.hcl` — it had also kept `CADDY_VERSION`
at 2.11.2.

## Verification

Built locally with `docker buildx bake caddy-alpine-latest` from this branch:

```console
$ docker run --rm --entrypoint caddy coraza-crs-test:caddy-v260 build-info | grep -E 'coraza|caddy/v2'
dep	github.com/caddyserver/caddy/v2	v2.11.4
dep	github.com/corazawaf/coraza-caddy/v2	v2.6.0
dep	github.com/corazawaf/coraza/v3	v3.7.0
```

WebSocket handshake through the same image, same command as above:

```console
HTTP/1.1 101 Switching Protocols
Connection: Upgrade
Sec-WebSocket-Accept: s3pPLMBiTxaQ9kYGzzhZRbK+xOo=
Server: Caddy
Upgrade: websocket
```

(curl then holds the tunnel until `-m 5` expires, as expected.)

Functional tests, unchanged, against the image built from this branch:

```console
$ tests/run-tests.sh -v caddy -i coraza-crs-test:caddy-v260
…
26/26 tests passed
```

Including `response body is inspected in phase 4`, so the gain from #78 is preserved.

## Out of scope, for the record

Streaming responses (SSE, grpc-gateway) are still held until the upstream response ends,
in v2.5.0 **and** v2.6.0: `rwInterceptor.Flush()` type-asserts `i.w.(http.Flusher)`, which
caddy has not satisfied since 2.6.3. That is corazawaf/coraza-caddy#344, still open —
nothing this repo can fix, but worth knowing that v2.6.0 does not address it.

I can add a WebSocket case to `tests/run-tests.sh` in a follow-up if you want the
regression covered in CI; it needs a WS-capable backend image alongside `traefik/whoami`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the bundled Caddy runtime to version 2.11.4.
  * Updated the bundled Coraza security engine to version 2.6.0.
  * Refreshed build and deployment configurations to use the latest versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->