### PR TITLE
fix: sync remaining compose pins, rename CORAZA_VERSION

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ The following configuration paths are shared across all variants:
 | Variable | Default | Description |
 | -------- | ------- | ----------- |
 | `CRS_VERSION` | `4.25.0` | OWASP CRS release version (LTS) |
-| `CADDY_VERSION` | `2.11.3` | Caddy Docker tag (caddy variant) |
+| `CADDY_VERSION` | `2.11.4` | Caddy Docker tag (caddy variant) |
 | `NGINX_VERSION` | `1.30.4` | nginx image version (nginx variant) |
 | `HTTPD_VERSION` | `2.4` | httpd image version (apache variant) |
 | `LIBCORAZA_VERSION` | `v1.6.0` | libcoraza release (nginx/apache variants) |

--- a/README.md
+++ b/README.md
@@ -215,12 +215,13 @@ The following configuration paths are shared across all variants:
 | Variable | Default | Description |
 | -------- | ------- | ----------- |
 | `CRS_VERSION` | `4.25.0` | OWASP CRS release version (LTS) |
-| `CADDY_VERSION` | `2.11.2` | Caddy Docker tag (caddy variant) |
+| `CADDY_VERSION` | `2.11.3` | Caddy Docker tag (caddy variant) |
 | `NGINX_VERSION` | `1.30.4` | nginx image version (nginx variant) |
 | `HTTPD_VERSION` | `2.4` | httpd image version (apache variant) |
 | `LIBCORAZA_VERSION` | `v1.6.0` | libcoraza release (nginx/apache variants) |
+| `CORAZA_CADDY_VERSION` | `v2.5.0` | coraza-caddy release (caddy variant) |
 | `CORAZA_NGINX_VERSION` | `0.11.4` | coraza-nginx release (nginx variant) |
-| `CORAZA_APACHE_VERSION` | `0.0.1` | coraza-apache release (apache variant) |
+| `CORAZA_APACHE_VERSION` | `0.3.0` | coraza-apache release (apache variant) |
 
 ## Building
 

--- a/caddy/Dockerfile
+++ b/caddy/Dockerfile
@@ -1,5 +1,5 @@
 # Set Caddy release tag
-ARG CADDY_VERSION="2.11.3@sha256:ec18ee54aab3315c22e25f3b2babda73ff8007d39b13b3bd1bfffa2f0444c7d9"
+ARG CADDY_VERSION="2.11.4"
 
 # Use official Caddy builder image
 FROM caddy:${CADDY_VERSION}-builder AS builder-caddy

--- a/caddy/Dockerfile
+++ b/caddy/Dockerfile
@@ -6,13 +6,13 @@ FROM caddy:${CADDY_VERSION}-builder AS builder-caddy
 
 # Set coraza-caddy release tag to build against
 # Available tags are on the GitHub releases page here: https://github.com/corazawaf/coraza-caddy/tags
-ARG CORAZA_VERSION="n/a"
+ARG CORAZA_CADDY_VERSION="n/a"
 
 # Build Caddy with Coraza
 # The module path must carry the /v2 suffix: without it Go resolves the v1
-# module (coraza-caddy v1.2.2), whatever CORAZA_VERSION says.
+# module (coraza-caddy v1.2.2), whatever CORAZA_CADDY_VERSION says.
 RUN --mount=type=cache,target=/go,id=caddy \
-  xcaddy build --with github.com/corazawaf/coraza-caddy/v2@${CORAZA_VERSION}
+  xcaddy build --with github.com/corazawaf/coraza-caddy/v2@${CORAZA_CADDY_VERSION}
 
 # Use official caddy builder image to get Core Rule Set
 FROM caddy:${CADDY_VERSION}-builder AS builder-crs

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -20,7 +20,7 @@ variable "caddy-version" {
     default = "2.11.3"
 }
 
-variable "coraza-version" {
+variable "coraza-caddy-version" {
     # renovate: depName=corazawaf/coraza-caddy datasource=github-releases
     default = "v2.5.0"
 }
@@ -120,7 +120,7 @@ target "platforms-base" {
     }
     args = {
         CADDY_VERSION = "${caddy-version}"
-        CORAZA_VERSION = "${coraza-version}"
+        CORAZA_CADDY_VERSION = "${coraza-caddy-version}"
     }
 }
 

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -17,7 +17,7 @@ variable "crs-versions" {
 
 variable "caddy-version" {
     # renovate: depName=caddy datasource=docker
-    default = "2.11.3"
+    default = "2.11.4"
 }
 
 variable "coraza-caddy-version" {

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -28,7 +28,7 @@ services:
         # renovate: depName=coreruleset/coreruleset datasource=github-releases
         CRS_VERSION: "4.25.0"
         # renovate: depName=caddy datasource=docker
-        CADDY_VERSION: "2.11.3"
+        CADDY_VERSION: "2.11.4"
         # renovate: depName=corazawaf/coraza-caddy datasource=github-releases
         CORAZA_CADDY_VERSION: "v2.5.0"
     depends_on:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -30,7 +30,7 @@ services:
         # renovate: depName=caddy datasource=docker
         CADDY_VERSION: "2.11.3"
         # renovate: depName=corazawaf/coraza-caddy datasource=github-releases
-        CORAZA_VERSION: "v2.5.0"
+        CORAZA_CADDY_VERSION: "v2.5.0"
     depends_on:
       - whoami
     networks:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -28,7 +28,7 @@ services:
         # renovate: depName=coreruleset/coreruleset datasource=github-releases
         CRS_VERSION: "4.25.0"
         # renovate: depName=caddy datasource=docker
-        CADDY_VERSION: "2.11.2"
+        CADDY_VERSION: "2.11.3"
         # renovate: depName=corazawaf/coraza-caddy datasource=github-releases
         CORAZA_VERSION: "v2.5.0"
     depends_on:
@@ -83,7 +83,7 @@ services:
         # renovate: depName=corazawaf/libcoraza datasource=github-releases
         LIBCORAZA_VERSION: "v1.6.0"
         # renovate: depName=corazawaf/coraza-apache datasource=github-releases
-        CORAZA_APACHE_VERSION: "0.0.1"
+        CORAZA_APACHE_VERSION: "0.3.0"
         # renovate: depName=httpd datasource=docker
         HTTPD_VERSION: "2.4"
     depends_on:

--- a/renovate.json
+++ b/renovate.json
@@ -5,10 +5,11 @@
   ],
   "customManagers": [
     {
-      "description": "Bake file",
+      "description": "Bake file and compose build args",
       "customType": "regex",
       "managerFilePatterns": [
-        "/^docker-bake\\.hcl$/"
+        "/^docker-bake\\.hcl$/",
+        "/^docker-compose\\.yaml$/"
       ],
       "matchStrings": [
         "depName=(?<depName>[^\\s]+)(?:\\s+packageName=(?<packageName>[^\\s]+))?\\s+datasource=(?<datasource>[^\\s]+)\\s+[^\"]+\"(?<currentValue>[^\"]+)\""


### PR DESCRIPTION
Rebased on main. #81 already bumped `LIBCORAZA_VERSION` to v1.6.0, which is the actual fix for #80 — the diagnosis for the record: `coraza_is_response_body_processable` was added to libcoraza in v1.4.0 (absent in v1.2.0 and v1.3.0), so coraza-nginx 0.11.4 linked against a library that did not export it. What remains here is the rest of the drift and the reason it happened.

The Renovate custom manager globbed `docker-bake.hcl` only, so the `# renovate:` comments in the compose file were never acted on and its pins froze at whatever was current when they were written. That is how the libcoraza pin fell four minor versions behind bake in the first place, and `CORAZA_APACHE_VERSION` (0.0.1 vs 0.3.0) and `CADDY_VERSION` (2.11.2 vs 2.11.3) drifted the same way.

Changes:

- `renovate.json`: the bake custom manager now also globs `docker-compose.yaml`, so both files stay in step
- `docker-compose.yaml`: `CORAZA_APACHE_VERSION` 0.0.1 → 0.3.0, `CADDY_VERSION` 2.11.2 → 2.11.3
- Rename `CORAZA_VERSION` → `CORAZA_CADDY_VERSION` in `caddy/Dockerfile`, `docker-compose.yaml`, and `docker-bake.hcl` (variable `coraza-version` → `coraza-caddy-version`). The arg pins the coraza-caddy module, and the bare name neither says so nor matches its `CORAZA_NGINX_VERSION` / `CORAZA_APACHE_VERSION` siblings
- `README.md`: build argument table picks up the Caddy and coraza-apache values, and gains the `CORAZA_CADDY_VERSION` row it never had

`CRS_VERSION` is left at 4.25.0, matching bake's `v4-lts-crs-version`. Once Renovate reads the compose file it will propose bumping that to the latest CRS; a `matchFileNames` packageRule can hold it at LTS if that pin is deliberate.

Verified locally: nginx builds and starts with no symbol error, `/` returns 200 and `?x=/etc/passwd&y=../../` returns 403. Apache builds at 0.3.0, loads 663 rules, same 200/403. Caddy builds after the rename, with xcaddy resolving `coraza-caddy/v2@v2.5.0`, and `docker buildx bake --print caddy-alpine` emits `CORAZA_CADDY_VERSION=v2.5.0`.

Refs #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated Caddy and Coraza components to newer versions for Caddy, nginx, Apache, and Caddy builds.
  * Standardized the Coraza Caddy build argument naming across build configuration and documentation.
  * Build automation now recognizes Docker Compose files alongside bake files.
  * Updated documented build arguments and version references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->