### PR TITLE
chore: track README versions with Renovate

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Three web server variants are available:
 
 | Variant | Base | Image Tag |
 | ------- | ---- | --------- |
-| [Caddy](https://caddyserver.com/) | Alpine 3.20 | `caddy-alpine` |
+| [Caddy](https://caddyserver.com/) | Alpine | `caddy-alpine` |
 | [nginx](https://nginx.org/) | Debian (nginx-unprivileged) | `nginx` |
 | [Apache](https://httpd.apache.org/) | Debian (httpd) | `apache` |
 

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -5,6 +5,7 @@ variable "crs-version" {
 }
 
 variable "v4-lts-crs-version" {
+    # renovate: depName=coreruleset-v4-lts packageName=coreruleset/coreruleset datasource=github-releases
     default = "4.25.0"
 }
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -25,7 +25,7 @@ services:
       context: .
       dockerfile: caddy/Dockerfile
       args:
-        # renovate: depName=coreruleset/coreruleset datasource=github-releases
+        # CRS v4 LTS line, bumped by hand like v4-lts-crs-version in docker-bake.hcl
         CRS_VERSION: "4.25.0"
         # renovate: depName=caddy datasource=docker
         CADDY_VERSION: "2.11.4"
@@ -48,7 +48,7 @@ services:
       context: .
       dockerfile: nginx/Dockerfile
       args:
-        # renovate: depName=coreruleset/coreruleset datasource=github-releases
+        # CRS v4 LTS line, bumped by hand like v4-lts-crs-version in docker-bake.hcl
         CRS_VERSION: "4.25.0"
         # renovate: depName=golang datasource=docker
         GOLANG_VERSION: "1.25"
@@ -76,7 +76,7 @@ services:
       context: .
       dockerfile: apache/Dockerfile
       args:
-        # renovate: depName=coreruleset/coreruleset datasource=github-releases
+        # CRS v4 LTS line, bumped by hand like v4-lts-crs-version in docker-bake.hcl
         CRS_VERSION: "4.25.0"
         # renovate: depName=golang datasource=docker
         GOLANG_VERSION: "1.25"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -25,7 +25,7 @@ services:
       context: .
       dockerfile: caddy/Dockerfile
       args:
-        # CRS v4 LTS line, bumped by hand like v4-lts-crs-version in docker-bake.hcl
+        # renovate: depName=coreruleset-v4-lts packageName=coreruleset/coreruleset datasource=github-releases
         CRS_VERSION: "4.25.0"
         # renovate: depName=caddy datasource=docker
         CADDY_VERSION: "2.11.4"
@@ -48,7 +48,7 @@ services:
       context: .
       dockerfile: nginx/Dockerfile
       args:
-        # CRS v4 LTS line, bumped by hand like v4-lts-crs-version in docker-bake.hcl
+        # renovate: depName=coreruleset-v4-lts packageName=coreruleset/coreruleset datasource=github-releases
         CRS_VERSION: "4.25.0"
         # renovate: depName=golang datasource=docker
         GOLANG_VERSION: "1.25"
@@ -76,7 +76,7 @@ services:
       context: .
       dockerfile: apache/Dockerfile
       args:
-        # CRS v4 LTS line, bumped by hand like v4-lts-crs-version in docker-bake.hcl
+        # renovate: depName=coreruleset-v4-lts packageName=coreruleset/coreruleset datasource=github-releases
         CRS_VERSION: "4.25.0"
         # renovate: depName=golang datasource=docker
         GOLANG_VERSION: "1.25"

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -36,7 +36,7 @@ RUN set -eux; \
 ## Stage 2: Build nginx module
 FROM nginx:${NGINX_VERSION} AS nginx-builder
 
-ARG NGINX_VERSION="n/a"
+ARG NGINX_VERSION
 ARG CORAZA_NGINX_VERSION="n/a"
 
 USER root

--- a/renovate.json
+++ b/renovate.json
@@ -22,21 +22,81 @@
         "/^README\\.md$/"
       ],
       "matchStrings": [
-        ".*on Caddy (?<currentValue>\\d+\\.\\d+\\.\\d+)"
+        "\\| `CADDY_VERSION` \\| `(?<currentValue>[^`]+)`"
       ],
       "depNameTemplate": "caddy",
       "datasourceTemplate": "docker"
     },
     {
-      "description": "Docs: CRS",
+      "description": "Docs: nginx",
       "customType": "regex",
       "managerFilePatterns": [
         "/^README\\.md$/"
       ],
       "matchStrings": [
-        "OWASP CRS (?<currentValue>\\d+\\.\\d+\\.\\d+)"
+        "\\| `NGINX_VERSION` \\| `(?<currentValue>[^`]+)`"
       ],
-      "depNameTemplate": "coreruleset/coreruleset",
+      "depNameTemplate": "nginxinc/nginx-unprivileged",
+      "datasourceTemplate": "docker"
+    },
+    {
+      "description": "Docs: httpd",
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/^README\\.md$/"
+      ],
+      "matchStrings": [
+        "\\| `HTTPD_VERSION` \\| `(?<currentValue>[^`]+)`"
+      ],
+      "depNameTemplate": "httpd",
+      "datasourceTemplate": "docker"
+    },
+    {
+      "description": "Docs: libcoraza",
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/^README\\.md$/"
+      ],
+      "matchStrings": [
+        "\\| `LIBCORAZA_VERSION` \\| `(?<currentValue>[^`]+)`"
+      ],
+      "depNameTemplate": "corazawaf/libcoraza",
+      "datasourceTemplate": "github-releases"
+    },
+    {
+      "description": "Docs: coraza-caddy",
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/^README\\.md$/"
+      ],
+      "matchStrings": [
+        "\\| `CORAZA_CADDY_VERSION` \\| `(?<currentValue>[^`]+)`"
+      ],
+      "depNameTemplate": "corazawaf/coraza-caddy",
+      "datasourceTemplate": "github-releases"
+    },
+    {
+      "description": "Docs: coraza-nginx",
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/^README\\.md$/"
+      ],
+      "matchStrings": [
+        "\\| `CORAZA_NGINX_VERSION` \\| `(?<currentValue>[^`]+)`"
+      ],
+      "depNameTemplate": "corazawaf/coraza-nginx",
+      "datasourceTemplate": "github-releases"
+    },
+    {
+      "description": "Docs: coraza-apache",
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/^README\\.md$/"
+      ],
+      "matchStrings": [
+        "\\| `CORAZA_APACHE_VERSION` \\| `(?<currentValue>[^`]+)`"
+      ],
+      "depNameTemplate": "corazawaf/coraza-apache",
       "datasourceTemplate": "github-releases"
     }
   ],

--- a/renovate.json
+++ b/renovate.json
@@ -16,6 +16,19 @@
       ]
     },
     {
+      "description": "Docs: CRS v4 LTS",
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/^README\\.md$/"
+      ],
+      "matchStrings": [
+        "\\| `CRS_VERSION` \\| `(?<currentValue>[^`]+)`"
+      ],
+      "depNameTemplate": "coreruleset-v4-lts",
+      "packageNameTemplate": "coreruleset/coreruleset",
+      "datasourceTemplate": "github-releases"
+    },
+    {
       "description": "Docs: caddy",
       "customType": "regex",
       "managerFilePatterns": [
@@ -102,9 +115,22 @@
   ],
   "packageRules": [
     {
+      "description": "compose, the README and the bake lts tag track the CRS v4 LTS line",
+      "matchDepNames": [
+        "coreruleset-v4-lts"
+      ],
+      "allowedVersions": ">=4.25.0 <4.26.0",
+      "groupName": "CRS v4 LTS updates"
+    },
+    {
       "description": "nginx uses odd minors for mainline and even minors for stable; only track stable",
-      "matchDatasources": ["docker"],
-      "matchPackageNames": ["nginx", "nginxinc/nginx-unprivileged"],
+      "matchDatasources": [
+        "docker"
+      ],
+      "matchPackageNames": [
+        "nginx",
+        "nginxinc/nginx-unprivileged"
+      ],
       "allowedVersions": "/^\\d+\\.\\d*[02468]\\.\\d+$/"
     }
   ]


### PR DESCRIPTION
Follow-up to #83. A local extraction run (`renovate --platform=local --dry-run=extract`) shows what Renovate actually sees, and `README.md` produced no deps at all: both README custom managers keyed on prose (`.*on Caddy \d+\.\d+\.\d+`, `OWASP CRS \d+\.\d+\.\d+`) that no longer exists in the file. So the build argument table has been hand-maintained, which is how its Caddy and coraza-apache rows ended up behind the bake defaults.

Everything else is covered, per the same run: the bake and compose pins via the custom manager, the three Dockerfiles via the built-in dockerfile manager (it resolves the `ARG` defaults for `NGINX_VERSION`, `CADDY_VERSION`, `GOLANG_VERSION`, `HTTPD_VERSION`), and the workflows via the github-actions manager.

Changes:

- `renovate.json`: the two dead doc managers are replaced by one manager per row of the build argument table, keyed on the variable name — CRS, caddy, nginxinc/nginx-unprivileged, httpd, libcoraza, coraza-caddy, coraza-nginx, coraza-apache
- CRS v4 LTS follows the shape modsecurity-crs-docker uses: the bake `v4-lts-crs-version` variable, the three compose `CRS_VERSION` args, and the README row all carry `depName=coreruleset-v4-lts packageName=coreruleset/coreruleset`, and a packageRule holds that alias to `>=4.25.0 <4.26.0`. Patch releases on the LTS line land on their own while `crs-version` tracks latest independently. Without the alias, teaching the manager to read the compose file in #83 would have pulled the LTS demo pins up to the latest CRS
- `README.md`: the variant table said Alpine 3.20 while `caddy:2.11.4` ships Alpine 3.23.5. The base follows whatever the Caddy image ships, so the patch version is dropped rather than pinned to a number nothing maintains
- `nginx/Dockerfile`: the builder stage redeclared `ARG NGINX_VERSION="n/a"`, so Renovate read the runtime image as `nginxinc/nginx-unprivileged:n/a` and skipped it. Declaring it bare inherits the global `1.30.4`

Verified with `renovate-config-validator` (passes) and two dry runs. Extraction: `README.md` now yields all eight deps with the right depName, datasource, and currentValue, each `replaceString` a literal substring of the table so autoreplace lands, and the `:n/a` dep is gone. Lookup: the five `coreruleset-v4-lts` pins resolve to 4.25.1 and `coreruleset/coreruleset` to 4.29.0, so the two lines move separately as intended. `docker buildx build --call=outline` reports `NGINX_VERSION 1.30.4` as the Dockerfile default, and the nginx image still builds, serves 200, and blocks with 403.

🤖 Generated with [Claude Code](https://claude.com/claude-code)