### PR TITLE
chore(renovate): skip release-age delay for corazawaf deps

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -115,6 +115,13 @@
   ],
   "packageRules": [
     {
+      "description": "first-party corazawaf releases skip the release-age delay",
+      "matchPackageNames": [
+        "corazawaf/**"
+      ],
+      "minimumReleaseAge": null
+    },
+    {
       "description": "compose, the README and the bake lts tag track the CRS v4 LTS line",
       "matchDepNames": [
         "coreruleset-v4-lts"


### PR DESCRIPTION
Adds a `packageRules` entry matching `corazawaf/**` with `minimumReleaseAge: null`, cancelling the 7-day delay inherited from `coreruleset/renovate-config` for the four first-party deps tracked here: `libcoraza`, `coraza-caddy`, `coraza-nginx`, `coraza-apache`.

`minimumReleaseAgeBehaviour: "timestamp-required"` from the preset still applies, so releases without a resolvable timestamp remain blocked.

Verified with `renovate-config-validator`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)