### PR TITLE
chore: bump coraza-nginx and coraza-apache to 0.21.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,8 +220,8 @@ The following configuration paths are shared across all variants:
 | `HTTPD_VERSION` | `2.4` | httpd image version (apache variant) |
 | `LIBCORAZA_VERSION` | `v1.7.0` | libcoraza release (nginx/apache variants) |
 | `CORAZA_CADDY_VERSION` | `v2.6.0` | coraza-caddy release (caddy variant) |
-| `CORAZA_NGINX_VERSION` | `0.20.1` | coraza-nginx release (nginx variant) |
-| `CORAZA_APACHE_VERSION` | `0.20.1` | coraza-apache release (apache variant) |
+| `CORAZA_NGINX_VERSION` | `0.21.0` | coraza-nginx release (nginx variant) |
+| `CORAZA_APACHE_VERSION` | `0.21.0` | coraza-apache release (apache variant) |
 
 ## Building
 

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -38,12 +38,12 @@ variable "libcoraza-version" {
 
 variable "coraza-nginx-version" {
     # renovate: depName=corazawaf/coraza-nginx datasource=github-releases
-    default = "0.20.1"
+    default = "0.21.0"
 }
 
 variable "coraza-apache-version" {
     # renovate: depName=corazawaf/coraza-apache datasource=github-releases
-    default = "0.20.1"
+    default = "0.21.0"
 }
 
 variable "nginx-version" {

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -55,7 +55,7 @@ services:
         # renovate: depName=corazawaf/libcoraza datasource=github-releases
         LIBCORAZA_VERSION: "v1.7.0"
         # renovate: depName=corazawaf/coraza-nginx datasource=github-releases
-        CORAZA_NGINX_VERSION: "0.20.1"
+        CORAZA_NGINX_VERSION: "0.21.0"
         # renovate: depName=nginxinc/nginx-unprivileged datasource=docker
         NGINX_VERSION: "1.30.4"
     depends_on:
@@ -83,7 +83,7 @@ services:
         # renovate: depName=corazawaf/libcoraza datasource=github-releases
         LIBCORAZA_VERSION: "v1.7.0"
         # renovate: depName=corazawaf/coraza-apache datasource=github-releases
-        CORAZA_APACHE_VERSION: "0.20.1"
+        CORAZA_APACHE_VERSION: "0.21.0"
         # renovate: depName=httpd datasource=docker
         HTTPD_VERSION: "2.4"
     depends_on:


### PR DESCRIPTION
Bumps the Coraza connectors to 0.21.0 (both were at 0.20.1).

- `docker-bake.hcl`: `coraza-nginx-version` and `coraza-apache-version` -> `0.21.0`
- `docker-compose.yaml`: `CORAZA_NGINX_VERSION` / `CORAZA_APACHE_VERSION` -> `0.21.0`
- `README.md`: the version table -> `0.21.0`

0.21.0 requires **libcoraza >= 1.7**, which this repo already pins (`libcoraza-version = v1.7.0`), so the builds are consistent: the Dockerfiles build libcoraza 1.7 and install its header before configuring the connector, satisfying coraza-nginx's new build-time `coraza_version_num()` probe and coraza-apache's runtime version gate.

Note for future bumps: from 0.21.0 the connectors enforce a hard libcoraza floor (>= 1.7). If a later connector raises that floor, `libcoraza-version` must move in lockstep — a mismatch now fails loudly (nginx: `./configure` errors "requires libcoraza >= 1.7.0"; apache: refuses to start), so it would surface in CI rather than ship silently.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Coraza Nginx and Apache connector versions from 0.20.1 to 0.21.0.
  * Aligned version references across build configuration, container orchestration, and project documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->