### PR TITLE
ci(release-please): use a GitHub App token instead of GITHUB_TOKEN

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -3,10 +3,7 @@ on:
     branches:
       - main
 
-permissions:
-  contents: write
-  pull-requests: write
-  issues: write
+permissions: {}
 
 name: release-please
 
@@ -14,8 +11,20 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        id: app-token
+        with:
+          app-id: ${{ secrets.RELEASE_PLEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_PLEASE_APP_PRIVATE_KEY }}
+          # Narrow the blanket installation permissions to what release-please
+          # needs: commits and the release branch, the release PR, its labels.
+          permission-contents: write
+          permission-pull-requests: write
+          permission-issues: write
+
       - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5
         with:
-          # this is not recommended, but we don't run any actions on release
-          token: ${{ secrets.GITHUB_TOKEN }}
+          # An app token, not GITHUB_TOKEN: Actions is not allowed to open PRs,
+          # and a GITHUB_TOKEN-created PR would not trigger verifyimage.yml.
+          token: ${{ steps.app-token.outputs.token }}
           release-type: simple


### PR DESCRIPTION
release-please currently fails at the last step ([run 33443675816](https://github.com/coreruleset/coraza-crs-docker/actions/runs/33443675816/job/99657604564)):

```
##[error]release-please failed: GitHub Actions is not permitted to create or approve pull requests.
```

Everything before that worked — it parsed the commits, created commit `10d994f` and updated `release-please--branches--main`. Only `POST /repos/.../pulls` was refused, by the repo/org "Allow GitHub Actions to create and approve pull requests" setting, which overrides the workflow's `permissions:` block.

Flipping that setting would fix the error, but a PR opened with `GITHUB_TOKEN` does not trigger workflows, and `verifyimage.yml` is `pull_request`-only — so release PRs would merge with no image builds behind them. An App token avoids both problems.

Changes:

- Mint a token with `actions/create-github-app-token` and hand it to `release-please-action`.
- Scope it to `contents`, `pull-requests`, and `issues` (labels on the release PR) rather than inheriting blanket installation permissions — zizmor flags the unscoped form as high severity.
- Drop the workflow-level `permissions:` to `{}`; `GITHUB_TOKEN` is no longer used.

## Required before merge

A GitHub App installed on this repo with **Contents: write**, **Pull requests: write**, **Issues: write**, and two repository secrets:

- `RELEASE_PLEASE_APP_ID`
- `RELEASE_PLEASE_APP_PRIVATE_KEY`

Without them the workflow fails at the token step. `actionlint` and `zizmor` are both clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated release automation to use a dedicated, narrowly scoped authorization method.
  - Improved the security and reliability of automated release publishing.
  - No changes to product functionality or the end-user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->