### PR TITLE
ci(release-please): pass the App client-id instead of app-id

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
-          app-id: ${{ secrets.RELEASE_PLEASE_APP_ID }}
+          client-id: ${{ secrets.RELEASE_PLEASE_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_PLEASE_APP_PRIVATE_KEY }}
           # Narrow the blanket installation permissions to what release-please
           # needs: commits and the release branch, the release PR, its labels.


### PR DESCRIPTION
Clears the warning on every release-please run:

```
##[warning]Input 'app-id' has been deprecated with message: Use 'client-id' instead.
```

`create-github-app-token` v3 marks `app-id` deprecated in its `action.yml` and takes `client-id` instead. Behaviour is otherwise identical — same App, same installation, same permissions.

## Required before merge

A new repository secret **`RELEASE_PLEASE_CLIENT_ID`**, holding the App's **Client ID** (`Iv23li…`, on the App's General settings page) — not the numeric App ID that `RELEASE_PLEASE_APP_ID` currently holds. `RELEASE_PLEASE_APP_PRIVATE_KEY` is unchanged.

Once this merges, `RELEASE_PLEASE_APP_ID` is unused and can be deleted.

`actionlint` and `zizmor` are both clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)