### PR TITLE
ci: auto-release on Renovate image-affecting merges

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,11 +40,14 @@ concurrency:
 jobs:
   release:
     runs-on: ubuntu-latest
-    # Manual dispatch always runs; a pull_request run only proceeds for a merged
-    # Renovate PR (a closed-but-not-merged PR, or anyone else's, is ignored).
+    # Only ever release from main: a manual dispatch must be on main (the UI/CLI
+    # let you pick any branch), and a Renovate PR must have targeted main. Never
+    # tag/publish an image from a feature or PR branch.
     if: >-
-      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'workflow_dispatch' &&
+       github.ref == 'refs/heads/main') ||
       (github.event.pull_request.merged == true &&
+       github.event.pull_request.base.ref == 'main' &&
        github.event.pull_request.user.login == 'renovate[bot]')
     steps:
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,11 @@
 # Cut a date-based release (CalVer, YYYYMMDD) and let publish.yml build the image.
 #
 # The repo has always tagged by date (20260828, 202608261, ...). release-please
-# is a SemVer tool and cannot emit those tags, so releases are cut here instead:
-# a manual dispatch creates a GitHub Release whose tag is today's UTC date, with
-# a numeric suffix on a same-day re-release (20260901 -> 202609011 -> 202609012).
+# is a SemVer tool and cannot emit those tags, so releases are cut here instead.
+# The tag is today's UTC date, with a numeric suffix on a same-day re-release
+# (20260901 -> 202609011 -> 202609012). Two triggers: a manual dispatch, and an
+# automatic run when Renovate merges a PR touching image-affecting files (so the
+# image tracks its bundled deps without a manual cut).
 #
 # publish.yml triggers on `release: [published]`. A release created with the
 # default GITHUB_TOKEN would NOT trigger it, so this uses the same GitHub App
@@ -17,6 +19,16 @@ on:
         description: "Override tag (default: today's UTC date, YYYYMMDD). Must not already exist."
         required: false
         type: string
+  # Auto-cut a release when Renovate merges a PR that changes what ships in the
+  # image. The paths filter limits it to image-affecting files, so CI-only
+  # Renovate bumps (GitHub Actions, README version tables) do not release; the
+  # job `if:` below further restricts it to a *merged* Renovate PR.
+  pull_request:
+    types: [closed]
+    paths:
+      - docker-bake.hcl
+      - docker-compose.yaml
+      - "**/Dockerfile"
 
 permissions: {}
 
@@ -28,6 +40,12 @@ concurrency:
 jobs:
   release:
     runs-on: ubuntu-latest
+    # Manual dispatch always runs; a pull_request run only proceeds for a merged
+    # Renovate PR (a closed-but-not-merged PR, or anyone else's, is ignored).
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.pull_request.merged == true &&
+       github.event.pull_request.user.login == 'renovate[bot]')
     steps:
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
@@ -42,7 +60,9 @@ jobs:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           GH_REPO: ${{ github.repository }}
           OVERRIDE: ${{ inputs.tag }}
-          SHA: ${{ github.sha }}
+          # On a merged PR, tag the merge commit on main (github.sha would be the
+          # PR head); on manual dispatch, github.sha is main's tip.
+          SHA: ${{ github.event.pull_request.merge_commit_sha || github.sha }}
         run: |
           set -euo pipefail
 


### PR DESCRIPTION
Follow-up to #97. Makes `release.yml` **also** cut a date-based release automatically when Renovate merges a change that affects what ships in the image — so the published image tracks its bundled deps without a manual dispatch each time.

## How it's scoped
- **`pull_request: [closed]` + `paths`** — triggers only when the PR touched image-affecting files (`docker-bake.hcl`, `docker-compose.yaml`, `**/Dockerfile`). CI-only Renovate bumps (GitHub Actions, README version tables, etc.) don't match, so they don't release.
- **job `if:`** — proceeds only for a *merged* PR authored by `renovate[bot]` (a closed-but-unmerged PR, or anyone else's, is ignored). Manual `workflow_dispatch` still always runs.
- **target SHA** — a merged PR tags the merge commit on main (`merge_commit_sha`); dispatch tags main's tip.

Bursts are safe: the existing `concurrency: release` serializes runs, and the same-day suffix (`20260902` → `202609021`) handles multiple releases in a day.

## Notes / assumptions
- Assumes Renovate runs as the GitHub App (`renovate[bot]` login) — the coreruleset preset does. A self-hosted bot under a different account would need the login adjusted.
- Renovate PRs are same-repo branches, so the `pull_request` run has secrets access for the App token (fork PRs wouldn't — not applicable here).
- This makes releases *reactive* to image-affecting dep bumps; deliberate/manual cuts are unchanged via dispatch.

If you'd rather it fire on *every* Renovate merge (not just image-affecting), drop the `paths` filter — but that would also release for CI-only bumps.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic date-based releases when qualifying Renovate pull requests are merged.
  * Releases can now be created manually or triggered by merged dependency updates affecting container configuration.

* **Bug Fixes**
  * Ensured automatically generated release tags reference the pull request’s merge commit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->